### PR TITLE
parse recipes

### DIFF
--- a/bakery.go
+++ b/bakery.go
@@ -14,7 +14,7 @@ func main() {
 
 	recipe, err := ParseBakefile(f)
 	if err != nil {
-		fmt.Printf("unable to parse the Bafile, %v", err)
+		fmt.Printf("unable to parse the Bakefile, %v", err)
 		return
 	}
 

--- a/models.go
+++ b/models.go
@@ -1,9 +1,24 @@
 package main
 
-type Recipe struct {
-	Version string `yaml:"version"`
-}
+import "fmt"
 
-func (r *Recipe) Valid() error {
+type (
+	Bakery struct {
+		Version string   `yaml:"version"`
+		Recipes []Recipe `yaml:"recipes"`
+	}
+
+	Recipe struct {
+		Description string   `yaml:"description"`
+		Default     bool     `yaml:"default"`
+		Steps       []string `yaml:"steps"`
+	}
+)
+
+func (r *Bakery) Valid() error {
+	if r.Recipes == nil {
+		return fmt.Errorf("no recipes found")
+	}
+
 	return nil
 }

--- a/models.go
+++ b/models.go
@@ -4,8 +4,8 @@ import "fmt"
 
 type (
 	Bakery struct {
-		Version string   `yaml:"version"`
-		Recipes []Recipe `yaml:"recipes"`
+		Version string            `yaml:"version"`
+		Recipes map[string]Recipe `yaml:"recipes"`
 	}
 
 	Recipe struct {

--- a/models_test.go
+++ b/models_test.go
@@ -1,0 +1,57 @@
+package main
+
+import "testing"
+
+func TestBakery_Valid(t *testing.T) {
+	type fields struct {
+		Version string
+		Recipes []Recipe
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "error no recipes",
+			fields: fields{
+				Version: "1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "success empty recipes",
+			fields: fields{
+				Version: "1",
+				Recipes: []Recipe{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success",
+			fields: fields{
+				Version: "1",
+				Recipes: []Recipe{
+					{
+						Description: "a step to list the filesystem",
+						Default:     false,
+						Steps: []string{
+							"ls -al",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Bakery{
+				Version: tt.fields.Version,
+				Recipes: tt.fields.Recipes,
+			}
+			if err := r.Valid(); (err != nil) != tt.wantErr {
+				t.Errorf("Bakery.Valid() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/models_test.go
+++ b/models_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestBakery_Valid(t *testing.T) {
 	type fields struct {
 		Version string
-		Recipes []Recipe
+		Recipes map[string]Recipe
 	}
 	tests := []struct {
 		name    string
@@ -23,7 +23,7 @@ func TestBakery_Valid(t *testing.T) {
 			name: "success empty recipes",
 			fields: fields{
 				Version: "1",
-				Recipes: []Recipe{},
+				Recipes: map[string]Recipe{},
 			},
 			wantErr: false,
 		},
@@ -31,8 +31,8 @@ func TestBakery_Valid(t *testing.T) {
 			name: "success",
 			fields: fields{
 				Version: "1",
-				Recipes: []Recipe{
-					{
+				Recipes: map[string]Recipe{
+					"list": {
 						Description: "a step to list the filesystem",
 						Default:     false,
 						Steps: []string{

--- a/parser.go
+++ b/parser.go
@@ -7,14 +7,18 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func ParseBakefile(f *os.File) (*Recipe, error) {
+func ParseBakefile(f *os.File) (*Bakery, error) {
 	content, err := ioutil.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}
 
-	var r Recipe
+	var r Bakery
 	if err := yaml.Unmarshal(content, &r); err != nil {
+		return nil, err
+	}
+
+	if err := r.Valid(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
adds code to parse recipes and make sure that they exist in the file. the syntax is valid as long as the `recipes` tag exists - it doesn't have to be populated.

resolves #3 