### PR TITLE
print help, version

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -42,11 +42,22 @@ func (r *Runner) RunCommand(b *Bakery, args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("not enough args provided")
 	}
-	recipe := args[0]
+	input := args[0]
 
-	rcp, ok := b.Recipes[recipe]
+	switch input {
+	case HelpCommand:
+		r.printHelp()
+	default:
+		r.run(b, input)
+	}
+
+	return nil
+}
+
+func (r *Runner) run(b *Bakery, input string) error {
+	rcp, ok := b.Recipes[input]
 	if !ok {
-		return fmt.Errorf("undefined recipe, %s", recipe)
+		return fmt.Errorf("undefined recipe, %s", input)
 	}
 
 	for i, step := range rcp.Steps {

--- a/runner.go
+++ b/runner.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	HelpCommand = "help"
+	HelpCmd    = "help"
+	VersionCmd = "version"
 )
 
 type (
@@ -45,8 +46,10 @@ func (r *Runner) RunCommand(b *Bakery, args []string) error {
 	input := args[0]
 
 	switch input {
-	case HelpCommand:
+	case HelpCmd:
 		r.printHelp(b)
+	case VersionCmd:
+		r.printVersion(b)
 	default:
 		return r.run(b, input)
 	}
@@ -75,6 +78,10 @@ func (r *Runner) printHelp(b *Bakery) {
 	for k, r := range b.Recipes {
 		fmt.Printf("- %s: %s\n", k, r.Description)
 	}
+}
+
+func (r *Runner) printVersion(b *Bakery) {
+	fmt.Printf("Bakefile Version: %s", b.Version)
 }
 
 func (e *DefaultExecutor) Run(cmd string) error {

--- a/runner.go
+++ b/runner.go
@@ -46,9 +46,9 @@ func (r *Runner) RunCommand(b *Bakery, args []string) error {
 
 	switch input {
 	case HelpCommand:
-		r.printHelp()
+		r.printHelp(b)
 	default:
-		r.run(b, input)
+		return r.run(b, input)
 	}
 
 	return nil
@@ -68,6 +68,13 @@ func (r *Runner) run(b *Bakery, input string) error {
 	}
 
 	return nil
+}
+
+func (r *Runner) printHelp(b *Bakery) {
+	fmt.Printf("Available Recipes in Bakefile:\n")
+	for k, r := range b.Recipes {
+		fmt.Printf("- %s: %s\n", k, r.Description)
+	}
 }
 
 func (e *DefaultExecutor) Run(cmd string) error {

--- a/runner_test.go
+++ b/runner_test.go
@@ -88,6 +88,28 @@ func TestRunner_RunCommand(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "success, print help",
+			fields: args{
+				b: &Bakery{
+					Recipes: map[string]Recipe{
+						"build": {
+							Steps:       []string{"go build *.go"},
+							Description: "builds the project using go",
+						},
+						"test": {
+							Steps:       []string{"go test -v ./..."},
+							Description: "",
+						},
+						"run": {
+							Steps: []string{"./run"},
+						},
+					},
+				},
+				args: []string{"help"},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/runner_test.go
+++ b/runner_test.go
@@ -110,6 +110,16 @@ func TestRunner_RunCommand(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "success, print version",
+			fields: args{
+				b: &Bakery{
+					Version: "0.6.9",
+				},
+				args: []string{"version"},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/runner_test.go
+++ b/runner_test.go
@@ -111,6 +111,7 @@ func TestRunner_RunCommand(t *testing.T) {
 			wantErr: false,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tc := tt


### PR DESCRIPTION
allows users to pass `bake help` to view the available recipes without needing to open the `Bakefile`. the function reads the `description` field of each `recipe` to print the `help`

moreover, implements the `bake version` that prints the version of the `Bakefile`. this is the (optional) `version` value defined in the `Bakefile`

resolves #6 
resolves #12 
