### PR TITLE
allow defaults

### DIFF
--- a/models.go
+++ b/models.go
@@ -4,13 +4,13 @@ import "fmt"
 
 type (
 	Bakery struct {
-		Version string            `yaml:"version"`
-		Recipes map[string]Recipe `yaml:"recipes"`
+		Version  string            `yaml:"version"`
+		Defaults []string          `yaml:"defaults"`
+		Recipes  map[string]Recipe `yaml:"recipes"`
 	}
 
 	Recipe struct {
 		Description string   `yaml:"description"`
-		Default     bool     `yaml:"default"`
 		Steps       []string `yaml:"steps"`
 	}
 )

--- a/models_test.go
+++ b/models_test.go
@@ -34,7 +34,6 @@ func TestBakery_Valid(t *testing.T) {
 				Recipes: map[string]Recipe{
 					"list": {
 						Description: "a step to list the filesystem",
-						Default:     false,
 						Steps: []string{
 							"ls -al",
 						},

--- a/runner.go
+++ b/runner.go
@@ -68,8 +68,8 @@ func (r *Runner) run(b *Bakery, input string) error {
 }
 
 func (r *Runner) runSteps(b *Bakery, steps []string) error {
-	for i, step := range steps {
-		fmt.Printf("[%d/%d] - %s\n", i+1, len(steps), step)
+	for _, step := range steps {
+		fmt.Printf("%s\n", step)
 
 		recipe, ok := b.Recipes[step]
 		if ok {

--- a/runner.go
+++ b/runner.go
@@ -63,7 +63,6 @@ func (r *Runner) run(b *Bakery, input string) error {
 	if !ok {
 		return fmt.Errorf("undefined recipe, %s", input)
 	}
-
 	return r.runSteps(b, rcp.Steps)
 }
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -32,13 +32,6 @@ func TestRunner_RunCommand(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "error no args",
-			fields: args{
-				b: &Bakery{},
-			},
-			wantErr: true,
-		},
-		{
 			name: "error undefined recipe",
 			fields: args{
 				b: &Bakery{
@@ -68,6 +61,58 @@ func TestRunner_RunCommand(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "error when default doesnt exist",
+			fields: args{
+				b: &Bakery{
+					Defaults: []string{"run"},
+					Recipes: map[string]Recipe{
+						"build": {
+							Steps: []string{"go build -o app ./..."},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error when default step fails",
+			fields: args{
+				b: &Bakery{
+					Defaults: []string{"build"},
+					Recipes: map[string]Recipe{
+						"build": {
+							Steps: []string{"go bild -o app ./..."},
+						},
+					},
+				},
+			},
+			executor: &testCommandExecutor{
+				executorHandler: func(cmd string) error {
+					return errors.New("unable to run command")
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "success defaults",
+			fields: args{
+				b: &Bakery{
+					Defaults: []string{"build"},
+					Recipes: map[string]Recipe{
+						"build": {
+							Steps: []string{"go build -o app ./..."},
+						},
+					},
+				},
+			},
+			executor: &testCommandExecutor{
+				executorHandler: func(cmd string) error {
+					return nil
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "success",

--- a/runner_test.go
+++ b/runner_test.go
@@ -96,6 +96,25 @@ func TestRunner_RunCommand(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "success when no defaults",
+			fields: args{
+				b: &Bakery{
+					Defaults: []string{},
+					Recipes: map[string]Recipe{
+						"build": {
+							Steps: []string{"go build -o app ./..."},
+						},
+					},
+				},
+			},
+			executor: &testCommandExecutor{
+				executorHandler: func(cmd string) error {
+					return nil
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "success defaults",
 			fields: args{
 				b: &Bakery{


### PR DESCRIPTION
allows users to define `defaults`. these are `recipes` that will run, it the user doesn't pass any parameters at all. for example, `bake` will run the steps defined in the defaults

resolves #14 