### PR TITLE
ignore failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # bakery 🧁 
 
 ![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/kampanosg/bakery/go.yml?style=for-the-badge&logo=go)
@@ -45,6 +44,13 @@ The `Recipe` syntax is defined below
 
 ℹ️ A `step` can reference a `recipe`
 
+#### Special Characters
+Some special keywords that are available to the `Bakefile`
+
+| character | usage | description                                                              |
+| --------- | ----- | ------------------------------------------------------------------------ |
+| `^`       | steps | prefix a step with this keyword to ignore errors and continue the recipe |
+
 ### Builtins
 The following builtin functions are available with `bake`
 
@@ -79,4 +85,9 @@ recipes:
       - test
       - build
       - "./app"
+  ignore-fail:
+    description: "prefix a step with ^ to ignore the failure"
+    steps:
+        - "^lss -abcdf ./not/valid/dir"
+        - "echo 'i will execute fine'"
 ```

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -70,7 +70,7 @@ func (r *Runner) run(b *models.Bakery, input string) error {
 
 func (r *Runner) runSteps(b *models.Bakery, steps []string) error {
 	for _, step := range steps {
-		ignoreFail := shouldIgnoreFailure(step)
+		ignoreFail := ignoreFail(step)
 		if ignoreFail {
 			step = step[1:]
 		}
@@ -132,6 +132,6 @@ func (r *Runner) GetPrintableAuthor(b *models.Bakery) string {
 	return buffer.String()
 }
 
-func shouldIgnoreFailure(step string) bool {
+func ignoreFail(step string) bool {
 	return strings.HasPrefix(step, IgnoreFailureToken)
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/kampanosg/bakery/internal/models"
 )
@@ -11,6 +12,8 @@ const (
 	HelpCmd    = "help"
 	VersionCmd = "version"
 	AuthorCmd  = "author"
+
+	IgnoreFailureToken = "^"
 )
 
 type (
@@ -67,6 +70,11 @@ func (r *Runner) run(b *models.Bakery, input string) error {
 
 func (r *Runner) runSteps(b *models.Bakery, steps []string) error {
 	for _, step := range steps {
+		ignoreFail := shouldIgnoreFailure(step)
+		if ignoreFail {
+			step = step[1:]
+		}
+
 		fmt.Printf("%s\n", step)
 
 		recipe, ok := b.Recipes[step]
@@ -78,6 +86,9 @@ func (r *Runner) runSteps(b *models.Bakery, steps []string) error {
 		}
 
 		if err := r.agent.Execute(step); err != nil {
+			if ignoreFail {
+				continue
+			}
 			return fmt.Errorf("unable to run step %s, %w", step, err)
 		}
 	}
@@ -119,4 +130,8 @@ func (r *Runner) GetPrintableAuthor(b *models.Bakery) string {
 	}
 	buffer.WriteString("\n")
 	return buffer.String()
+}
+
+func shouldIgnoreFailure(step string) bool {
+	return strings.HasPrefix(step, IgnoreFailureToken)
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -208,6 +208,25 @@ func TestRunner_RunCommand(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "success, ignore failure",
+			fields: args{
+				b: &models.Bakery{
+					Recipes: map[string]models.Recipe{
+						"list": {
+							Steps: []string{"^lss -al"},
+						},
+					},
+				},
+				args: []string{"list"},
+			},
+			executor: &testCommandAgent{
+				executorHandler: func(cmd string) error {
+					return errors.New("syntaxt error, lss is not valid")
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### description
adds a new special keyword `^`. when steps are prefixed with this, then the recipe continues even if that step fails. the error is still reported in the `stdout`

example usage:
```yaml
recipes:
  create-network:
    description: "this will fail if the network exists"
    steps:  
      - "^ docker create network test-api"
  up:
    steps:
      - create-network
      - "docker compose ..."
```

resolves #32 