### PR TITLE
fixes whitespace bug and cleaner output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-Bakefile
-Bakefile.yaml
-Bakefile.yml
 bake

--- a/Bakefile
+++ b/Bakefile
@@ -1,0 +1,14 @@
+version: 1.1.0
+metadata:
+    author: kampanosg
+default:
+    - test
+recipes:
+    test:
+        description: "test the code with go test"
+        steps:
+            - "go test -cover -parallel 1 ./..."
+    build:
+        description: "builds the code with go"
+        steps:
+            - "go build -o bake bakery.go"

--- a/Bakefile
+++ b/Bakefile
@@ -11,4 +11,5 @@ recipes:
     build:
         description: "builds the code with go"
         steps:
+            - "^rm bake"
             - "go build -o bake bakery.go"

--- a/Bakefile
+++ b/Bakefile
@@ -4,6 +4,10 @@ metadata:
 default:
     - test
 recipes:
+    clean:
+        description: "deletes executable"
+        steps:
+            - "rm bake"
     test:
         description: "test the code with go test"
         steps:
@@ -11,5 +15,5 @@ recipes:
     build:
         description: "builds the code with go"
         steps:
-            - "^rm bake"
+            - "^ clean"
             - "go build -o bake bakery.go"

--- a/bakery.go
+++ b/bakery.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 
+	"github.com/fatih/color"
 	"github.com/kampanosg/bakery/internal/loader"
 	"github.com/kampanosg/bakery/internal/parser"
 	"github.com/kampanosg/bakery/internal/runner"
+)
+
+var (
+	c = color.New(color.FgRed)
 )
 
 func main() {
@@ -26,14 +30,14 @@ func main() {
 	}
 
 	if err != nil {
-		fmt.Printf("unable to load the Bakefile, %v\n", err)
+		c.Printf("unable to load the Bakefile, %v\n", err)
 		return
 	}
 	defer f.Close()
 
 	recipe, err := parser.ParseBakefile(f)
 	if err != nil {
-		fmt.Printf("unable to parse the Bakefile, %v\n", err)
+		c.Printf("unable to parse the Bakefile, %v\n", err)
 		return
 	}
 
@@ -41,6 +45,6 @@ func main() {
 
 	r := runner.NewRunner(&runner.OSAgent{})
 	if err := r.RunCommand(recipe, args); err != nil {
-		fmt.Printf("run failed, %v\n", err)
+		c.Printf("run failed, %v\n", err)
 	}
 }

--- a/bakery.go
+++ b/bakery.go
@@ -50,5 +50,5 @@ func main() {
 		return
 	}
 
-	green.Println("done")
+	green.Println("done!")
 }

--- a/bakery.go
+++ b/bakery.go
@@ -11,7 +11,8 @@ import (
 )
 
 var (
-	c = color.New(color.FgRed)
+	red   = color.New(color.FgRed)
+	green = color.New(color.FgGreen)
 )
 
 func main() {
@@ -30,14 +31,14 @@ func main() {
 	}
 
 	if err != nil {
-		c.Printf("unable to load the Bakefile, %v\n", err)
+		red.Printf("unable to load the Bakefile, %v\n", err)
 		return
 	}
 	defer f.Close()
 
 	recipe, err := parser.ParseBakefile(f)
 	if err != nil {
-		c.Printf("unable to parse the Bakefile, %v\n", err)
+		red.Printf("unable to parse the Bakefile, %v\n", err)
 		return
 	}
 
@@ -45,6 +46,9 @@ func main() {
 
 	r := runner.NewRunner(&runner.OSAgent{})
 	if err := r.RunCommand(recipe, args); err != nil {
-		c.Printf("run failed, %v\n", err)
+		red.Printf("run failed, %v\n", err)
+		return
 	}
+
+	green.Println("done")
 }

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,10 @@ toolchain go1.21.0
 require gopkg.in/yaml.v2 v2.4.0
 
 require github.com/kampanosg/match v0.0.0-20230817135728-e29b1b058524
+
+require (
+	github.com/fatih/color v1.15.0 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.17 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,15 @@
+github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
+github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/kampanosg/match v0.0.0-20230817135728-e29b1b058524 h1:LQSbNwZHLyky3M7kW/QAgXd29/vqUDC1gxGTYh6LiyM=
 github.com/kampanosg/match v0.0.0-20230817135728-e29b1b058524/go.mod h1:SYDH4TlcIYqEwj108y1l33ndaUaQICAfnu3iSXou9Bc=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
+github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/kampanosg/bakery/internal/models"
 )
 
@@ -14,6 +15,10 @@ const (
 	AuthorCmd  = "author"
 
 	IgnoreFailureToken = "^"
+)
+
+var (
+	printer = color.New(color.FgCyan)
 )
 
 type (
@@ -41,21 +46,21 @@ func (r *Runner) RunCommand(b *models.Bakery, args []string) error {
 		return r.runDefaults(b)
 	}
 
-	var print string
+	var msg string
 	input := args[0]
 
 	switch input {
 	case HelpCmd:
-		print = r.GetPrintableHelp(b)
+		msg = r.GetPrintableHelp(b)
 	case VersionCmd:
-		print = r.GetPrintableVersion(b)
+		msg = r.GetPrintableVersion(b)
 	case AuthorCmd:
-		print = r.GetPrintableAuthor(b)
+		msg = r.GetPrintableAuthor(b)
 	default:
 		return r.run(b, input)
 	}
 
-	fmt.Printf(print)
+	printer.Printf("%s", msg)
 
 	return nil
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -18,7 +18,8 @@ const (
 )
 
 var (
-	printer = color.New(color.FgCyan)
+	cyan  = color.New(color.FgCyan)
+	cyanU = color.New(color.FgCyan).Add(color.Underline)
 )
 
 type (
@@ -60,7 +61,7 @@ func (r *Runner) RunCommand(b *models.Bakery, args []string) error {
 		return r.run(b, input)
 	}
 
-	printer.Printf("%s", msg)
+	cyan.Printf("%s", msg)
 
 	return nil
 }
@@ -80,7 +81,7 @@ func (r *Runner) runSteps(b *models.Bakery, steps []string) error {
 			step = step[1:]
 		}
 
-		fmt.Printf("%s\n", step)
+		cyanU.Printf("> %s\n", step)
 
 		recipe, ok := b.Recipes[step]
 		if ok {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -81,6 +81,8 @@ func (r *Runner) runSteps(b *models.Bakery, steps []string) error {
 			step = step[1:]
 		}
 
+		step = strings.TrimSpace(step)
+
 		cyanU.Printf("> %s\n", step)
 
 		recipe, ok := b.Recipes[step]

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -227,6 +227,31 @@ func TestRunner_RunCommand(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "success, ignore whitespace",
+			fields: args{
+				b: &models.Bakery{
+					Recipes: map[string]models.Recipe{
+						"clean": {
+							Steps: []string{"rm app"},
+						},
+						"build": {
+							Steps: []string{
+								"^ clean",
+								"go build -o app ./...",
+							},
+						},
+					},
+				},
+				args: []string{"build"},
+			},
+			executor: &testCommandAgent{
+				executorHandler: func(cmd string) error {
+					return errors.New("syntaxt error, lss is not valid")
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -247,7 +247,7 @@ func TestRunner_RunCommand(t *testing.T) {
 			},
 			executor: &testCommandAgent{
 				executorHandler: func(cmd string) error {
-					return errors.New("syntaxt error, lss is not valid")
+					return nil
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
the PR addresses the following:
- fixes a bug that if a step referencing a recipe had whitespace, the recipe would not be found
- adds coloured `fmt` to make the steps a bit more visible
- adds a `Bakefile` for the project

fixes #36 
resolves #34 
resolves #33 