### PR TITLE
multiple args

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -47,21 +47,22 @@ func (r *Runner) RunCommand(b *models.Bakery, args []string) error {
 	}
 
 	var msg string
-	input := args[0]
 
-	switch input {
-	case HelpCmd:
-		msg = r.GetPrintableHelp(b)
-	case VersionCmd:
-		msg = r.GetPrintableVersion(b)
-	case AuthorCmd:
-		msg = r.GetPrintableAuthor(b)
-	default:
-		return r.run(b, input)
+	for _, input := range args {
+
+		switch input {
+		case HelpCmd:
+			msg = r.GetPrintableHelp(b)
+		case VersionCmd:
+			msg = r.GetPrintableVersion(b)
+		case AuthorCmd:
+			msg = r.GetPrintableAuthor(b)
+		default:
+			return r.run(b, input)
+		}
+
+		cyan.Printf("%s", msg)
 	}
-
-	cyan.Printf("%s", msg)
-
 	return nil
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -252,6 +252,31 @@ func TestRunner_RunCommand(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "success, multiple recipes",
+			fields: args{
+				b: &models.Bakery{
+					Recipes: map[string]models.Recipe{
+						"clean": {
+							Steps: []string{"rm app"},
+						},
+						"build": {
+							Steps: []string{
+								"^ clean",
+								"go build -o app ./...",
+							},
+						},
+					},
+				},
+				args: []string{"build", "clean"},
+			},
+			executor: &testCommandAgent{
+				executorHandler: func(cmd string) error {
+					return nil
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
allows users to pass multiple args into the `bake` executable. for example 
```sh
bake one two three
```
resolves #40 