### PR TITLE
overload help

### DIFF
--- a/Bakefile.yaml
+++ b/Bakefile.yaml
@@ -19,3 +19,12 @@ recipes:
     steps:
       - "^ clean"
       - "go build -o :name: bakery.go"
+help: |
+  varsion: 1.2
+  Welcome to the demo Bakefile! It provides a good starting point with all the available syntax.
+  Here's the available commands:
+    * clean: deletes the executable
+    * test: tests the code with go test
+    * build: builds the code with go
+
+  For more information visit https://github.com/kampanosg/bakery

--- a/README.md
+++ b/README.md
@@ -94,4 +94,8 @@ recipes:
     steps:
         - "^lss -abcdf ./not/valid/dir"
         - "echo 'i will execute fine'"
+help: |
+  This is an example help message. It will override the built-in `bake help`
+
+  And it can be multiline as well!
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Below are the keywords that the `Bakefile` can contain
 | `variables`| `map[string]string` | Y        | user defined variables that can be used in the recipes with the `:var:` syntax |
 | `defaults` | `[]string`          | Y        | a list of recipes that will be called if no recipe is passed at execution      |
 | `recipes`  | `[]Recipe`          | N        | the list of recipes, see the table below how to define them                    |
+| `help`     | `string`            | Y        | a custom message that overrides the built-in `bake help`                       |
 
 #### Recipe
 The `Recipe` syntax is defined below

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -9,6 +9,7 @@ type (
 		Variables map[string]string `yaml:"variables"`
 		Defaults  []string          `yaml:"defaults"`
 		Recipes   map[string]Recipe `yaml:"recipes"`
+		Help      string            `yaml:"help"`
 	}
 
 	Recipe struct {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -144,6 +144,20 @@ func TestParseBakefile(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "success with custom help",
+			args: args{
+				path: "test-files/Bakefile-help",
+			},
+			want: &models.Bakery{
+				Help: "this is a custom help message",
+				Recipes: map[string]models.Recipe{
+					"list": {
+						Steps: []string{"ls -al"},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/parser/test-files/Bakefile-help
+++ b/internal/parser/test-files/Bakefile-help
@@ -1,0 +1,5 @@
+recipes:
+  list:
+    steps:
+      - "ls -al"
+help: "this is a custom help message"

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -49,7 +49,6 @@ func (r *Runner) RunCommand(b *models.Bakery, args []string) error {
 	var msg string
 
 	for _, input := range args {
-
 		switch input {
 		case HelpCmd:
 			msg = r.GetPrintableHelp(b)
@@ -118,6 +117,10 @@ func (r *Runner) runDefaults(b *models.Bakery) error {
 }
 
 func (r *Runner) GetPrintableHelp(b *models.Bakery) string {
+	if b.Help != "" {
+		return b.Help
+	}
+
 	var buffer bytes.Buffer
 	buffer.WriteString("Available Recipes in Bakefile:\n")
 	for k, r := range b.Recipes {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -428,6 +428,18 @@ func TestRunner_GetPrintableHelp(t *testing.T) {
 			},
 			want: "Available Recipes in Bakefile:\n- list: lists files in dir\n- build: builds the app\n",
 		},
+		{
+			name: "success when help is defined",
+			fields: fields{
+				agent: &testCommandAgent{},
+			},
+			args: args{
+				b: &models.Bakery{
+					Help: "This is the help",
+				},
+			},
+			want: "This is the help",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
allows users to define a custom `help` message. it overloads the built-in `help`

resolves #42