### PR TITLE
remove unnecessary verbose check

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -64,10 +64,8 @@ func (r *Runner) Run(b *models.Bakery, args []string) error {
 			}
 		}
 
-		if r.verbose {
-			if _, err := cyan.Printf("%s", msg); err != nil {
-				fmt.Printf("%s\n", msg)
-			}
+		if _, err := cyan.Printf("%s", msg); err != nil {
+			fmt.Printf("%s\n", msg)
 		}
 	}
 	return nil


### PR DESCRIPTION
fixes a bug where the `bake help` would not be printed if `-v` was not passed